### PR TITLE
Add permission check for deleting a study

### DIFF
--- a/app/Monitor/Data/DataSeeder.cs
+++ b/app/Monitor/Data/DataSeeder.cs
@@ -116,7 +116,7 @@ public class DataSeeder
         new()
         {
           Key = ConfigKey.RandomisationThreshold,
-          Name = "Randomisation Alert Threshold",
+          Name = "Study Capacity Alert Threshold",
           Value = "0.75",
           Description = "Sets the occupancy threshold for randomisation groups in a study. Alerts will trigger for any studies that pass this threshold.",
           Type = ConfigType.Double
@@ -124,7 +124,7 @@ public class DataSeeder
         new()
         {
           Key = ConfigKey.RandomisationJobFrequency,
-          Name = "Randomisation Alert Frequency",
+          Name = "Study Capacity Alert Frequency",
           Value = "23:00:00",
           Description = "How often we check the threshold of randomisation groups in the study",
           Type = ConfigType.TimeSpan

--- a/app/frontend-webapp/app/studies/columns.tsx
+++ b/app/frontend-webapp/app/studies/columns.tsx
@@ -9,9 +9,11 @@ import {
   XIcon,
 } from "lucide-react";
 import Link from "next/link";
+import { useSession } from "next-auth/react";
 import { useRef } from "react";
 
 import { deleteStudy } from "@/api/studies";
+import { hasPermission, permissions } from "@/auth/permissions";
 import { ConfirmationDialog } from "@/components/ConfirmationDialog";
 import { DataTableColumnHeader } from "@/components/data-table/DataTableColumnHeader";
 import EnvironmentBadge from "@/components/EnvironmentBadge";
@@ -115,6 +117,7 @@ export const columns: ColumnDef<StudyPartial>[] = [
     cell: ({ row }) => {
       const study = row.original;
       const deleteButtonRef = useRef<HTMLButtonElement | null>(null);
+      const { data: session } = useSession();
 
       const handleDelete = async (id: number) => {
         const response = await deleteStudy(id);
@@ -169,15 +172,19 @@ export const columns: ColumnDef<StudyPartial>[] = [
                 View
               </DropdownMenuItem>
             </Link>
-            <DropdownMenuItem
-              onClick={(e: React.MouseEvent<HTMLElement>) => {
-                e.preventDefault();
-                deleteButtonRef.current?.click();
-              }}
-            >
-              <XIcon className={icon({})} />
-              Delete
-            </DropdownMenuItem>
+
+            {hasPermission(session?.permissions, permissions.DeleteStudies) && (
+              <DropdownMenuItem
+                onClick={(e: React.MouseEvent<HTMLElement>) => {
+                  e.preventDefault();
+                  deleteButtonRef.current?.click();
+                }}
+              >
+                <XIcon className={icon({})} />
+                Delete
+              </DropdownMenuItem>
+            )}
+
             <div className={visuallyHidden()}>
               <ConfirmationDialog
                 title="Are you sure you want to delete this study?"


### PR DESCRIPTION
Fixes the bug where any user could see the delete study button (they still couldn't delete a study, but could try!)

And fixes randomisation config should be called Study Capacity.

